### PR TITLE
apply titleTextColor before adding it to builder

### DIFF
--- a/android/src/main/java/ui/bottomactionsheet/RNBottomActionSheetModule.java
+++ b/android/src/main/java/ui/bottomactionsheet/RNBottomActionSheetModule.java
@@ -94,11 +94,11 @@ public class RNBottomActionSheetModule extends ReactContextBaseJavaModule {
     BottomSheetBuilder bottomSheetBuilder = new BottomSheetBuilder(getCurrentActivity());
     bottomSheetBuilder = bottomSheetBuilder.setMode(BottomSheetBuilder.MODE_LIST);
     if(title != null && title.trim().length() > 0) {
-      bottomSheetBuilder = bottomSheetBuilder.addTitleItem(title);
-
       if (titleTextColor != null && titleTextColor.length() > 0) {
         bottomSheetBuilder = bottomSheetBuilder.setTitleTextColor(Color.parseColor(titleTextColor));
       }
+
+      bottomSheetBuilder = bottomSheetBuilder.addTitleItem(title);
     }
     if (itemTextColor != null && itemTextColor.length() > 0) {
       bottomSheetBuilder = bottomSheetBuilder.setItemTextColor(Color.parseColor(itemTextColor));


### PR DESCRIPTION
Inside bottom sheet builder `titleTextColor` is applied only in `addTitleItem()` so we need to call `setTitleTextColor()` before that.
